### PR TITLE
Add/rest api/block directory

### DIFF
--- a/src/wp-includes/blocks/rss.php
+++ b/src/wp-includes/blocks/rss.php
@@ -92,7 +92,7 @@ function render_block_core_rss( $attributes ) {
 		$class .= ' ' . $attributes['className'];
 	}
 
-	return sprintf( "<ul class='%s'>%s</ul>", esc_attr( $class ), $list_items );
+	return "<ul class='{$class}'>{$list_items}</ul>";
 }
 
 /**

--- a/src/wp-includes/blocks/search.php
+++ b/src/wp-includes/blocks/search.php
@@ -57,7 +57,7 @@ function render_block_core_search( $attributes ) {
 
 	return sprintf(
 		'<form class="%s" role="search" method="get" action="%s">%s</form>',
-		esc_attr( $class ),
+		$class,
 		esc_url( home_url( '/' ) ),
 		$label_markup . $input_markup . $button_markup
 	);

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -265,6 +265,10 @@ function create_initial_rest_routes() {
 	$controller = new WP_REST_Block_Renderer_Controller;
 	$controller->register_routes();
 
+	// Block Directory.
+	$controller = new WP_REST_Block_Directory_Controller;
+	$controller->register_routes();
+
 	// Settings.
 	$controller = new WP_REST_Settings_Controller;
 	$controller->register_routes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -20,7 +20,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 * Constructs the controller.
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-directory';
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -171,7 +171,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			return $filesystem_available;
 		}
 
-		$api = plugins_api(
+		$api = @plugins_api(
 			'plugin_information',
 			array(
 				'slug'   => $slug,
@@ -289,13 +289,17 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		$response = plugins_api(
+		$response = @plugins_api(
 			'query_plugins',
 			array(
 				'block'    => $search_string,
 				'per_page' => 3,
 			)
 		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
 		$result = array();
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -391,4 +391,128 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		return $block;
 	}
+
+	/**
+	 * Retrieves the theme's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'block',
+			'type'       => 'object',
+			'properties' => array(
+				'name'                => array(
+					'description'       => __( "The block name, in namespace/block-name format." ),
+					'type'              => 'string',
+					'context'           => array( 'view' ),
+				),
+				'title'               => array(
+					'description'       => __( "The block title, in human readable format." ),
+					'type'              => 'string',
+					'context'           => array( 'view' ),
+				),
+				'description'         => array(
+					'description'       => __( "A short description of the block, in human readable format." ),
+					'type'              => 'string',
+					'context'           => array( 'view' ),
+				),
+				'id'                  => array(
+					'description'       => __( "The block slug." ),
+					'type'              => 'string',
+					'context'           => array( 'view' ),
+				),
+				'rating'              => array(
+					'description'       => __( "The star rating of the block." ),
+					'type'              => 'integer',
+					'context'           => array( 'view' ),
+				),
+				'rating_count'        => array(
+					'description'       => __( "The number of ratings." ),
+					'type'              => 'integer',
+					'context'           => array( 'view' ),
+				),
+				'active_installs'     => array(
+					'description'       => __( "The number sites that have activated this block." ),
+					'type'              => 'integer',
+					'context'           => array( 'view' ),
+				),
+				'author_block_rating' => array(
+					'description'       => __( "The average rating of blocks published by the same author." ),
+					'type'              => 'integer',
+					'context'           => array( 'view' ),
+				),
+				'author_block_count'  => array(
+					'description'       => __( "The number of blocks published by the same author." ),
+					'type'              => 'integer',
+					'context'           => array( 'view' ),
+				),
+				'author'              => array(
+					'description'       => __( "The WordPress.org username of the block author." ),
+					'type'              => 'integer',
+					'context'           => array( 'view' ),
+				),
+				'icon' => array(
+					'description'     => __( "The WordPress.org username of the block author." ),
+					'type'              => 'string',
+					'format'            => 'uri',
+					'context'           => array( 'view' ),
+				),
+				'humanized_updated'   => array(
+					'description'       => __( "The date when the block was last updated, in fuzzy human readable format." ),
+					'type'              => 'string',
+					'context'           => array( 'view' ),
+				),
+				'assets'              => array(
+					'description'       => __( 'An object representing the block CSS and JavaScript assets.' ),
+					'type'              => 'array',
+					'context'           => array( 'view' ),
+					'readonly'          => true,
+					'items'             => array(
+						'type'            => 'string',
+						'format'          => 'uri',
+					),
+
+				),
+
+			),
+		);
+
+		return $schema;
+	}
+
+
+	/**
+	 * Retrieves the search params for the blocks collection.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['term'] = array(
+			'description'       => __( 'Limit result set to blocks matching the search term.' ),
+			'type'              => 'array',
+			'term'             => array(
+				'type' => 'string',
+			),
+			'required'          => true,
+			'sanitize_callback' => array( $this, 'sanitize_text_field' ),
+		);
+
+		/**
+		 * Filter collection parameters for the block directory controller.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param array $query_params JSON Schema-formatted collection parameters.
+		 */
+		return apply_filters( 'rest_block_directory_collection_params', $query_params );
+	}
+
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * Start: Include for phase 2
+ * Block Directory REST API: WP_REST_Blocks_Controller class
+ *
+ * @package gutenberg
+ * @since 6.5.0
+ */
+
+/**
+ * Controller which provides REST endpoint for the blocks.
+ *
+ * @since 6.5.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'block-directory';
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/search',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => array(
+					'term' => array(
+						'required' => true,
+					),
+				),
+				'schema'              => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/install',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'install_block' ),
+				'permission_callback' => array( $this, 'install_items_permissions_check' ),
+				'args'                => array(
+					'slug' => array(
+						'required' => true,
+					),
+				),
+				'schema'              => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/uninstall',
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'uninstall_block' ),
+				'permission_callback' => array( $this, 'delete_items_permissions_check' ),
+				'args'                => array(
+					'slug' => array(
+						'required' => true,
+					),
+				),
+				'schema'              => array( $this, 'get_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks whether a given request has permission to install and activate plugins.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'activate_plugins' ) ) {
+			return new WP_Error(
+				'rest_user_cannot_view',
+				__( 'Sorry, you are not allowed to install blocks.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+	/* phpcs:enable */
+
+	/**
+	 * Checks whether a given request has permission to install and activate plugins.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+	 */
+	public function install_items_permissions_check( $request ) {
+		$plugin = $request->get_param( 'slug' );
+
+		if (
+			! current_user_can( 'install_plugins' ) ||
+			! current_user_can( 'activate_plugins' ) ||
+			! current_user_can( 'activate_plugin', $plugin )
+		) {
+			return new WP_Error(
+				'rest_user_cannot_view',
+				__( 'Sorry, you are not allowed to install blocks.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a given request has permission to remove/deactivate plugins.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+	 */
+	public function delete_items_permissions_check( $request ) {
+		$plugin = $request->get_param( 'slug' );
+
+		if (
+			! current_user_can( 'delete_plugins' ) ||
+			! current_user_can( 'deactivate_plugins' ) ||
+			! current_user_can( 'deactivate_plugin', $plugin )
+		) {
+			return new WP_Error(
+				'rest_user_cannot_delete',
+				__( 'Sorry, you are not allowed to uninstall blocks.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Installs and activates a plugin
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function install_block( $request ) {
+
+		include_once( ABSPATH . 'wp-admin/includes/file.php' );
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
+		include_once( ABSPATH . 'wp-admin/includes/plugin-install.php' );
+
+		$slug = $request->get_param( 'slug' );
+
+		// Verify filesystem is accessible first.
+		$filesystem_available = self::is_filesystem_available();
+		if ( is_wp_error( $filesystem_available ) ) {
+			return $filesystem_available;
+		}
+
+		$api = plugins_api(
+			'plugin_information',
+			array(
+				'slug'   => $slug,
+				'fields' => array(
+					'sections' => false,
+				),
+			)
+		);
+
+		if ( is_wp_error( $api ) ) {
+			return $api;
+		}
+
+		$skin     = new WP_Ajax_Upgrader_Skin();
+		$upgrader = new Plugin_Upgrader( $skin );
+
+		$result = $upgrader->install( $api->download_link );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// This should be the same as $result above.
+		if ( is_wp_error( $skin->result ) ) {
+			return $skin->result;
+		}
+
+		if ( $skin->get_errors()->has_errors() ) {
+			return $skin->get_errors();
+		}
+
+		if ( is_null( $result ) ) {
+			global $wp_filesystem;
+			// Pass through the error from WP_Filesystem if one was raised.
+			if ( $wp_filesystem instanceof WP_Filesystem_Base && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
+				return new WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ) );
+			}
+			return new WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
+		}
+
+		// Find the plugin to activate it.
+		$plugin_files = get_plugins( '/' . $slug );
+		$plugin_files = array_keys( $plugin_files );
+
+		$plugin_file = $slug . '/' . reset( $plugin_files );
+
+		activate_plugin( $plugin_file );
+
+		return rest_ensure_response( true );
+	}
+
+	/**
+	 * Deactivates and deletes a plugin
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function uninstall_block( $request ) {
+
+		include_once( ABSPATH . 'wp-admin/includes/file.php' );
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
+		include_once( ABSPATH . 'wp-admin/includes/plugin-install.php' );
+
+		$slug = trim( $request->get_param( 'slug' ) );
+
+		if ( ! $slug ) {
+			return new WP_Error( 'slug_not_provided', 'Valid slug not provided.' );
+		}
+
+		// Verify filesystem is accessible first.
+		$filesystem_available = self::is_filesystem_available();
+		if ( is_wp_error( $filesystem_available ) ) {
+			return $filesystem_available;
+		}
+
+		$plugin_files = get_plugins( '/' . $slug );
+
+		if ( ! $plugin_files ) {
+			return new WP_Error( 'block_not_found', 'Valid slug not provided.' );
+		}
+
+		$plugin_files = array_keys( $plugin_files );
+		$plugin_file  = $slug . '/' . reset( $plugin_files );
+
+		deactivate_plugins( $plugin_file );
+
+		$delete_result = delete_plugins( array( $plugin_file ) );
+
+		if ( is_wp_error( $delete_result ) ) {
+			return $delete_result;
+		}
+
+		return rest_ensure_response( true );
+	}
+
+	/**
+	 * Search and retrieve blocks metadata
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+
+		$search_string = trim( $request->get_param( 'term' ) );
+
+		if ( empty( $search_string ) ) {
+			return rest_ensure_response( array() );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$response = plugins_api(
+			'query_plugins',
+			array(
+				'block'    => $search_string,
+				'per_page' => 3,
+			)
+		);
+
+		$result = array();
+
+		foreach ( $response->plugins as $plugin ) {
+			$installed_plugins = get_plugins( '/' . $plugin['slug'] );
+
+			// Only show uninstalled blocks.
+			if ( empty( $installed_plugins ) ) {
+				$result[] = self::parse_block_metadata( $plugin );
+			}
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Determine if the endpoints are available.
+	 *
+	 * Only the 'Direct' filesystem transport, and SSH/FTP when credentials are stored are supported at present.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return bool|WP_Error True if filesystem is available, WP_Error otherwise.
+	 */
+	private static function is_filesystem_available() {
+		$filesystem_method = get_filesystem_method();
+
+		if ( 'direct' === $filesystem_method ) {
+			return true;
+		}
+
+		ob_start();
+		$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
+		ob_end_clean();
+
+		if ( $filesystem_credentials_are_stored ) {
+			return true;
+		}
+
+		return new WP_Error( 'fs_unavailable', __( 'The filesystem is currently unavailable for installing blocks.', 'gutenberg' ) );
+	}
+
+	/**
+	 * Parse block metadata for a block
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_Object $plugin The plugin metadata.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	private static function parse_block_metadata( $plugin ) {
+		$block = new stdClass();
+
+		// There might be multiple blocks in a plugin. Only the first block is mapped.
+		$block_data   = reset( $plugin['blocks'] );
+		$block->name  = $block_data['name'];
+		$block->title = $block_data['title'];
+		if ( ! $block->title ) {
+			$block->title = $plugin['name'];
+		}
+
+		// Plugin's description, not description in block.json.
+		$block->description = wp_trim_words( wp_strip_all_tags( $plugin['description'] ), 30, '...' );
+
+		$block->id                  = $plugin['slug'];
+		$block->rating              = $plugin['rating'] / 20;
+		$block->rating_count        = $plugin['num_ratings'];
+		$block->active_installs     = $plugin['active_installs'];
+		$block->author_block_rating = $plugin['author_block_rating'] / 20;
+		$block->author_block_count  = $plugin['author_block_count'];
+
+		// Plugin's author, not author in block.json.
+		$block->author = wp_strip_all_tags( $plugin['author'] );
+
+		// Plugin's icons or icon in block.json.
+		$block->icon = isset( $plugin['icons']['1x'] ) ? $plugin['icons']['1x'] : 'block-default';
+
+		$block->assets = array();
+		foreach ( $plugin['block_assets'] as $asset ) {
+			// TODO: Return from API, not client-set.
+			$block->assets[] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
+		}
+
+		$block->humanized_updated = sprintf(
+			/* translators: %s: Human-readable time difference. */
+			__( '%s ago', 'gutenberg' ),
+			human_time_diff( strtotime( $plugin['last_updated'] ), current_time( 'timestamp' ) )
+		);
+
+		return $block;
+	}
+}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -433,7 +433,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				),
 				'active_installs'     => array(
 					'description'       => __( "The number sites that have activated this block." ),
-					'type'              => 'integer',
+					'type'              => 'string',
 					'context'           => array( 'view' ),
 				),
 				'author_block_rating' => array(
@@ -448,11 +448,11 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				),
 				'author'              => array(
 					'description'       => __( "The WordPress.org username of the block author." ),
-					'type'              => 'integer',
+					'type'              => 'string',
 					'context'           => array( 'view' ),
 				),
 				'icon' => array(
-					'description'     => __( "The WordPress.org username of the block author." ),
+					'description'     => __( "The block icon." ),
 					'type'              => 'string',
 					'format'            => 'uri',
 					'context'           => array( 'view' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -308,7 +308,8 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 			// Only show uninstalled blocks.
 			if ( empty( $installed_plugins ) ) {
-				$result[] = self::prepare_item_for_response( $plugin, $request );
+				$data = $this->prepare_item_for_response( $plugin, $request );
+				$result[] = $this->prepare_response_for_collection( $data );
 			}
 		}
 
@@ -351,7 +352,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
-	private static function prepare_item_for_repsonse( $plugin, $request ) {
+	public function prepare_item_for_response( $plugin, $request ) {
 
 		// There might be multiple blocks in a plugin. Only the first block is mapped.
 		$block_data   = reset( $plugin['blocks'] );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -398,7 +398,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'block',
+			'title'      => 'block-directory-item',
 			'type'       => 'object',
 			'properties' => array(
 				'name'                => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -370,7 +370,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			'author_block_count'    => intval( $plugin['author_block_count'] ),
 			'author'                => wp_strip_all_tags( $plugin['author'] ),
 			'icon'                  => ( isset( $plugin['icons']['1x'] ) ? $plugin['icons']['1x'] : 'block-default' ),
-			'asssets'               => array(),
+			'assets'                => array(),
 			'humanized_updated'     => sprintf(
 				/* translators: %s: Human-readable time difference. */
 				__( '%s ago', 'gutenberg' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -501,7 +501,6 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				'type' => 'string',
 			),
 			'required'          => true,
-			'sanitize_callback' => array( $this, 'sanitize_text_field' ),
 		);
 
 		/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -115,7 +115,8 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		) {
 			return new WP_Error(
 				'rest_user_cannot_view',
-				__( 'Sorry, you are not allowed to install blocks.', 'gutenberg' )
+				__( 'Sorry, you are not allowed to install blocks.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
 			);
 		}
 
@@ -140,7 +141,8 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		) {
 			return new WP_Error(
 				'rest_user_cannot_delete',
-				__( 'Sorry, you are not allowed to uninstall blocks.', 'gutenberg' )
+				__( 'Sorry, you are not allowed to uninstall blocks.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
 			);
 		}
 
@@ -181,6 +183,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		);
 
 		if ( is_wp_error( $api ) ) {
+			$api->add_data( array( 'status' => 500 ) );
 			return $api;
 		}
 
@@ -206,9 +209,9 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			global $wp_filesystem;
 			// Pass through the error from WP_Filesystem if one was raised.
 			if ( $wp_filesystem instanceof WP_Filesystem_Base && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
-				return new WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ) );
+				return new WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ), array( 'status' => 500 ) );
 			}
-			return new WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
+			return new WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ), array( 'status' => 500 ) );
 		}
 
 		// Find the plugin to activate it.
@@ -240,7 +243,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$slug = trim( $request->get_param( 'slug' ) );
 
 		if ( ! $slug ) {
-			return new WP_Error( 'slug_not_provided', 'Valid slug not provided.' );
+			return new WP_Error( 'slug_not_provided', 'Valid slug not provided.', array( 'status' => 400 ) );
 		}
 
 		// Verify filesystem is accessible first.
@@ -252,7 +255,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$plugin_files = get_plugins( '/' . $slug );
 
 		if ( ! $plugin_files ) {
-			return new WP_Error( 'block_not_found', 'Valid slug not provided.' );
+			return new WP_Error( 'block_not_found', 'Valid slug not provided.', array( 'status' => 400 ) );
 		}
 
 		$plugin_files = array_keys( $plugin_files );
@@ -297,6 +300,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$response->add_data( array( 'status' => 500 ) );
 			return $response;
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -360,7 +360,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$block = array(
 			'name'                  => $block_data['name'],
 			'title'                 => ( $block_data['title'] ? $block_data['title'] : $plugin['name'] ),
-			'description'           => wp_trim_words( wp_strip_all_tags( $plugin['description'] ), 30, '...' ),
+			'description'           => wp_trim_words( $plugin['description'], 30, '...' ),
 			'id'                    => $plugin['slug'],
 			'rating'                => $plugin['rating'] / 20,
 			'rating_count'          => intval( $plugin['num_ratings'] ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * Start: Include for phase 2
- * Block Directory REST API: WP_REST_Blocks_Controller class
+ * Block Directory REST API: WP_REST_Block_Directory_Controller class
  *
- * @package gutenberg
  * @since 6.5.0
  */
 
@@ -340,7 +339,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			return true;
 		}
 
-		return new WP_Error( 'fs_unavailable', __( 'The filesystem is currently unavailable for installing blocks.', 'gutenberg' ) );
+		return new WP_Error( 'fs_unavailable', __( 'The filesystem is currently unavailable for installing blocks.' ) );
 	}
 
 	/**
@@ -373,7 +372,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			'assets'                => array(),
 			'humanized_updated'     => sprintf(
 				/* translators: %s: Human-readable time difference. */
-				__( '%s ago', 'gutenberg' ),
+				__( '%s ago' ),
 				human_time_diff( strtotime( $plugin['last_updated'] ), current_time( 'timestamp' ) )
 			),
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -399,7 +399,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
-		$schema = array(
+		$this->schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-directory-item',
 			'type'       => 'object',
@@ -480,7 +480,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			),
 		);
 
-		return $schema;
+		return $this->schema;
 	}
 
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -366,10 +366,10 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		$block->id                  = $plugin['slug'];
 		$block->rating              = $plugin['rating'] / 20;
-		$block->rating_count        = $plugin['num_ratings'];
+		$block->rating_count        = intval( $plugin['num_ratings'] );
 		$block->active_installs     = $plugin['active_installs'];
 		$block->author_block_rating = $plugin['author_block_rating'] / 20;
-		$block->author_block_count  = $plugin['author_block_count'];
+		$block->author_block_count  = intval( $plugin['author_block_count'] );
 
 		// Plugin's author, not author in block.json.
 		$block->author = wp_strip_all_tags( $plugin['author'] );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -386,8 +386,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			$block[ 'assets' ][] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
 		}
 
-		$response = new WP_REST_Response();
-		$response->set_data( $block );
+		$response = new WP_REST_Response( $block );
 
 		return $response;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -171,7 +171,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			return $filesystem_available;
 		}
 
-		$api = @plugins_api(
+		$api = plugins_api(
 			'plugin_information',
 			array(
 				'slug'   => $slug,
@@ -289,7 +289,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		$response = @plugins_api(
+		$response = plugins_api(
 			'query_plugins',
 			array(
 				'block'    => $search_string,

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -254,6 +254,7 @@ require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-comments-controller
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-search-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-blocks-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-renderer-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-directory-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-settings-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-themes-controller.php';
 require ABSPATH . WPINC . '/rest-api/fields/class-wp-rest-meta-fields.php';

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Test WP_REST_Block_Directory_Controller_Test()
+ *
+ * @package Gutenberg
+ * phpcs:disable
+ */
+class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
+	protected $controller = null;
+
+	function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server;
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+
+		$this->controller = new WP_REST_Block_Directory_Controller();
+		$this->controller->register_routes();
+
+	}
+
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/block-directory/search', $routes );
+		$this->assertArrayHasKey( '/wp/v2/block-directory/install', $routes );
+		$this->assertArrayHasKey( '/wp/v2/block-directory/uninstall', $routes );
+	}
+
+	/**
+	 * Tests that an error is returned if the block plugin slug is not provided
+	 */
+	function test_should_throw_no_slug_error() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/install', [] );
+
+		$result = $this->controller->install_block( $request );
+		$this->assertWPError( $result, 'Returns an error when a slug isn\'t passed' );
+		$this->assertTrue( array_key_exists( 'plugins_api_failed', $result->errors ), 'Returns the correct error key' );
+	}
+
+	/**
+	 * Tests that the search endpoint does not return an error
+	 */
+	function test_simple_search() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
+		$request->set_query_params( array( 'term' => 'foo' ) );
+
+		$result = $this->controller->get_items( $request );
+		$this->assertNotWPError( $result );
+		$this->assertEquals( 200, $result->status );
+	}
+
+	/**
+	 * Simulate a network failure on outbound http requests to a given hostname.
+	 */
+	function prevent_requests_to_host( $blocked_host = 'api.wordpress.org' ) {
+		// apply_filters( 'pre_http_request', false, $parsed_args, $url );
+		add_filter( 'pre_http_request', function( $return, $args, $url ) use ( $blocked_host ) {
+			if ( @parse_url( $url, PHP_URL_HOST ) === $blocked_host ) {
+				return new WP_Error( 'plugins_api_failed', "An expected error occurred connecting to $blocked_host because of a unit test", "cURL error 7: Failed to connect to $blocked_host port 80: Connection refused" );
+
+			}
+			return $return;
+		}, 10, 3 );
+	}
+
+	/**
+	 * Tests that the search endpoint returns WP_Error when the server is unreachable.
+	 */
+	function test_search_unreachable() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
+		$request->set_query_params( array( 'term' => 'foo' ) );
+
+		$this->prevent_requests_to_host( 'api.wordpress.org' );
+
+		$result = $this->controller->get_items( $request );
+		$this->assertWPError( $result );
+		var_dump( $result );
+		$this->assertTrue( array_key_exists( 'plugins_api_failed', $result->errors ), 'Returns the correct error key' );
+
+	}
+
+	/**
+	 * Should fail with a permission error if requesting user is not logged in.
+	 */
+	function test_simple_search_no_perms() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'rest_user_cannot_view' );
+	}
+
+	/**
+	 * Make sure a search with the right permissions returns something.
+	 */
+	function test_simple_search_with_perms() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// This will hit the live API. We're searching for `block` which should definitely return at least one result.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
+		$request->set_query_params( array( 'term' => 'block' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->status );
+		// At least one result
+		$this->assertGreaterThanOrEqual( 1, count( $data ) );
+		// Each result should be an object with important attributes set
+		foreach ( $data as $plugin ) {
+			$this->assertObjectHasAttribute( 'name', $plugin );
+			$this->assertObjectHasAttribute( 'title', $plugin );
+			$this->assertObjectHasAttribute( 'id', $plugin );
+			$this->assertObjectHasAttribute( 'author_block_rating', $plugin );
+			$this->assertObjectHasAttribute( 'assets', $plugin );
+			$this->assertObjectHasAttribute( 'humanized_updated', $plugin );
+		}
+	}
+
+}

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -33,7 +33,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 	 * Tests that an error is returned if the block plugin slug is not provided
 	 */
 	function test_should_throw_no_slug_error() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/install', [] );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/block-directory/install', [] );
 
 		$result = $this->controller->install_block( $request );
 		$this->assertWPError( $result, 'Returns an error when a slug isn\'t passed' );
@@ -85,7 +85,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 	 * Tests that the install endpoint returns WP_Error when the server is unreachable.
 	 */
 	function test_install_unreachable() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/install' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/block-directory/install' );
 		$request->set_query_params( array( 'slug' => 'foo' ) );
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -86,6 +86,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 	 */
 	function test_simple_search_no_perms() {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
+		$request->set_query_params( array( 'term' => 'foo' ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -77,7 +77,6 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 
 		$result = $this->controller->get_items( $request );
 		$this->assertWPError( $result );
-		var_dump( $result );
 		$this->assertTrue( array_key_exists( 'plugins_api_failed', $result->errors ), 'Returns the correct error key' );
 
 	}

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -82,6 +82,21 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the install endpoint returns WP_Error when the server is unreachable.
+	 */
+	function test_install_unreachable() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/install' );
+		$request->set_query_params( array( 'slug' => 'foo' ) );
+
+		$this->prevent_requests_to_host( 'api.wordpress.org' );
+
+		$result = $this->controller->install_block( $request );
+		$this->assertWPError( $result );
+		$this->assertTrue( array_key_exists( 'plugins_api_failed', $result->errors ), 'Returns the correct error key' );
+
+	}
+
+	/**
 	 * Should fail with a permission error if requesting user is not logged in.
 	 */
 	function test_simple_search_no_perms() {

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -170,6 +170,9 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 	 * Make sure the search schema is available and correct.
 	 */
 	function test_search_schema() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/block-directory/search' );
 		$request->set_query_params( array( 'term' => 'foo' ) );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -166,5 +166,26 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( $data['message'], 'Plugin not found.' );
 	}
 
+	/**
+	 * Make sure the search schema is available and correct.
+	 */
+	function test_search_schema() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/block-directory/search' );
+		$request->set_query_params( array( 'term' => 'foo' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+      	// Check endpoints
+		$this->assertEquals( [ 'GET' ], $data['endpoints'][0]['methods'] );
+		$this->assertEquals( [ 'term' => [ 'required' => true ] ], $data['endpoints'][0]['args'] );
+
+		// Check schema
+		$this->assertEquals( [
+			'description' => __( "The block name, in namespace/block-name format." ),
+			'type'        => [ 'string' ],
+			'context'     => [ 'view' ],
+		], $data['schema']['properties']['name'] );
+		// TODO: ..etc..
+	}
 
 }

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -5,7 +5,7 @@
  * @package Gutenberg
  * phpcs:disable
  */
-class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
+class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 	protected $controller = null;
 
 	function setUp() {

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -14,7 +14,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server;
 		$this->server   = $wp_rest_server;
-		do_action( 'rest_api_init' );
+		do_action( 'rest_api_init', $this->server );
 
 		$this->controller = new WP_REST_Block_Directory_Controller();
 		$this->controller->register_routes();

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -126,12 +126,12 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 1, count( $data ) );
 		// Each result should be an object with important attributes set
 		foreach ( $data as $plugin ) {
-			$this->assertObjectHasAttribute( 'name', $plugin );
-			$this->assertObjectHasAttribute( 'title', $plugin );
-			$this->assertObjectHasAttribute( 'id', $plugin );
-			$this->assertObjectHasAttribute( 'author_block_rating', $plugin );
-			$this->assertObjectHasAttribute( 'assets', $plugin );
-			$this->assertObjectHasAttribute( 'humanized_updated', $plugin );
+			$this->assertArrayHasKey( 'name', $plugin );
+			$this->assertArrayHasKey( 'title', $plugin );
+			$this->assertArrayHasKey( 'id', $plugin );
+			$this->assertArrayHasKey( 'author_block_rating', $plugin );
+			$this->assertArrayHasKey( 'assets', $plugin );
+			$this->assertArrayHasKey( 'humanized_updated', $plugin );
 		}
 	}
 

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -137,6 +137,22 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * A search with zero results should return a 200 response.
+	 */
+	function test_simple_search_no_results() {
+		wp_set_current_user( self::$admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
+		$request->set_query_params( array( 'term' => '0c4549ee68f24eaaed46a49dc983ecde' ) );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		// Should produce a 200 status with an empty array.
+		$this->assertEquals( 200, $response->status );
+		$this->assertEquals( array(), $data );
+	}
+
+	/**
 	 * Should fail with a permission error if requesting user is not logged in.
 	 */
 	function test_simple_install_no_perms() {

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -79,7 +79,8 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );
 
-		$response = @ rest_do_request( $request );
+		$this->expectException('PHPUnit_Framework_Error_Warning');
+		$response = rest_do_request( $request );
 		$this->assertErrorResponse( 'plugins_api_failed', $response, 500 );
 	}
 
@@ -94,7 +95,8 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );
 
-		$response = @ rest_do_request( $request );
+		$this->expectException('PHPUnit_Framework_Error_Warning');
+		$response = rest_do_request( $request );
 		$this->assertErrorResponse( 'plugins_api_failed', $response, 500 );
 	}
 

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -35,7 +35,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 		wp_set_current_user( self::$admin_id );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/block-directory/install', [] );
-		$result = rest_get_server()->dispatch( $request );
+		$result = rest_do_request( $request );
 
 		$this->assertErrorResponse( 'rest_missing_callback_param', $result, 400 );
 	}
@@ -49,7 +49,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
 		$request->set_query_params( array( 'term' => 'foo' ) );
 
-		$result = rest_get_server()->dispatch( $request );
+		$result = rest_do_request( $request );
 		$this->assertNotWPError( $result );
 		$this->assertEquals( 200, $result->status );
 	}
@@ -79,7 +79,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );
 
-		$response = @ rest_get_server()->dispatch( $request );
+		$response = @ rest_do_request( $request );
 		$this->assertErrorResponse( 'plugins_api_failed', $response, 500 );
 	}
 
@@ -94,7 +94,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );
 
-		$response = @ rest_get_server()->dispatch( $request );
+		$response = @ rest_do_request( $request );
 		$this->assertErrorResponse( 'plugins_api_failed', $response, 500 );
 	}
 
@@ -104,7 +104,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 	function test_simple_search_no_perms() {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
 		$request->set_query_params( array( 'term' => 'foo' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$response = rest_do_request( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( $data['code'], 'rest_user_cannot_view' );
@@ -119,7 +119,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 		// This will hit the live API. We're searching for `block` which should definitely return at least one result.
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
 		$request->set_query_params( array( 'term' => 'block' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$response = rest_do_request( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->status );
@@ -142,7 +142,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 	function test_simple_install_no_perms() {
 		$request  = new WP_REST_Request( 'POST', '/wp/v2/block-directory/install' );
 		$request->set_query_params( array( 'slug' => 'foo' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$response = rest_do_request( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( $data['code'], 'rest_user_cannot_view' );
@@ -157,7 +157,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 		// This will hit the live API. 
 		$request  = new WP_REST_Request( 'POST', '/wp/v2/block-directory/install' );
 		$request->set_query_params( array( 'slug' => 'alex-says-this-block-definitely-doesnt-exist' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$response = rest_do_request( $request );
 
 		// Is this an appropriate status?
 		$this->assertErrorResponse( 'plugins_api_failed', $response, 500 );
@@ -171,7 +171,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_TestCase {
 
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/block-directory/search' );
 		$request->set_query_params( array( 'term' => 'foo' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$response = rest_do_request( $request );
 		$data     = $response->get_data();
 
       	// Check endpoints

--- a/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
+++ b/tests/phpunit/tests/rest-api/class-wp-rest-block-directory-controller-test.php
@@ -75,7 +75,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );
 
-		$result = $this->controller->get_items( $request );
+		$result = @ $this->controller->get_items( $request );
 		$this->assertWPError( $result );
 		$this->assertTrue( array_key_exists( 'plugins_api_failed', $result->errors ), 'Returns the correct error key' );
 
@@ -90,7 +90,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_UnitTestCase {
 
 		$this->prevent_requests_to_host( 'api.wordpress.org' );
 
-		$result = $this->controller->install_block( $request );
+		$result = @ $this->controller->install_block( $request );
 		$this->assertWPError( $result );
 		$this->assertTrue( array_key_exists( 'plugins_api_failed', $result->errors ), 'Returns the correct error key' );
 


### PR DESCRIPTION
Here's a first attempt at moving the block directory API endpoints into core. Still WIP.

Some known issues:
* Schemas are not working (`test_search_schema()` fails).
* The endpoint structure isn't ideal, but I've stuck with the same structure to ensure the Gutenberg plugin can switch between them.
* Unit tests need more coverage, especially for the install and uninstall endpoints.

Plenty of unknown issues too.